### PR TITLE
Introduce the concept of `bulkPerform`

### DIFF
--- a/addon/-scheduler.js
+++ b/addon/-scheduler.js
@@ -58,6 +58,17 @@ const Scheduler = Ember.Object.extend({
     this._flushQueues();
   },
 
+  scheduleBulk(taskInstances) {
+    taskInstances.forEach((taskInstance) => {
+      taskInstance.task.incrementProperty('numQueued');
+    });
+
+    set(this, 'lastPerformed', get(taskInstances, 'lastObject'));
+    this.incrementProperty('performCount', taskInstances.length);
+    this.queuedTaskInstances.push(...taskInstances);
+    this._flushQueues();
+  },
+
   _flushQueues() {
     let seen = [];
 

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -305,6 +305,18 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
    * @instance
    */
   perform(...args) {
+    let taskInstance = this._perform(args);
+    this._scheduler.schedule(taskInstance);
+    return taskInstance;
+  },
+
+  performBulk(instances) {
+    let taskInstances = instances.map((instanceArgs) => this._perform(instanceArgs));
+    this._scheduler.scheduleBulk(taskInstances)
+    return taskInstances;
+  },
+
+  _perform(args) {
     let fullArgs = this._curryArgs ? [...this._curryArgs, ...args] : args;
     let taskInstance = this._taskInstanceFactory.create({
       fn: this.fn,
@@ -320,7 +332,6 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
       taskInstance.cancel();
     }
 
-    this._scheduler.schedule(taskInstance);
     return taskInstance;
   },
 
@@ -328,6 +339,7 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
     return this.perform(...args);
   },
 });
+
 
 /**
   A {@link TaskProperty} is the Computed Property-like object returned


### PR DESCRIPTION
In our app code we perform many (~2000) tasks at the same time. This causes a noticeable browser freeze (exasperated because we are using [`enqueueWithPriority`](https://github.com/machty/ember-concurrency/pull/154) and the sort function takes some time but present with straight `enqueue`).

In our app this takes down the time the function takes to execute from this:

![before](https://user-images.githubusercontent.com/9898/27234621-999f8898-52b5-11e7-93a0-87e5d12c1fc9.png)

To this:

![after](https://user-images.githubusercontent.com/9898/27234634-9fb9347c-52b5-11e7-9a8d-3489672b0bf9.png)

What do you think about this approach? I can clean it up and add tests if you think it is worthwhile...